### PR TITLE
fix: nvidia

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,6 @@ If you have `page flip timeouts` (freezing screen) on AMD systems:
 
 ### NVIDIA
 
-> Tip: You may want to apply the steps in Secure Boot subsection first.
-
 See the following source for more information <https://negativo17.org/nvidia-driver/>.
 
 Disable the current RPMFusion repo first:
@@ -132,11 +130,47 @@ Change `gpgkey=` of `/etc/yum.repos.d/fedora-nvidia.repo`, to lookup the GPG loc
 +gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-slaanesh
 ```
 
+Remove any cached GPG keys:
+
+```bash
+# rm -rf /var/cache/rpm-ostree/repomd/fedora-nvidia-43-x86_64/RPM-GPG-KEY-slaanesh
+```
+
 Install the nvidia driver:
 
 ```bash
 rpm-ostree refresh-md
 rpm-ostree install nvidia-driver nvidia-settings
+systemctl reboot
+```
+
+#### Secure Boot
+
+After reboot, the `nvidia` model may reject loading when Secure Boot is enabled.
+
+As a workaround, see <https://github.com/CheariX/silverblue-akmods-keys> for details.
+
+> Tip: This package may also be used for other applications that require a signed module, such as VirtualBox.
+
+Make sure the Machine Owner Key (MOK) is enrolled (the key may already exists and enrolled, do not force):
+
+```bash
+# kmodgenca
+# mokutil --import /etc/pki/akmods/certs/public_key.der
+```
+
+Clone the `silverblue-akmods-keys project`:
+
+```bash
+git clone https://github.com/CheariX/silverblue-akmods-keys
+cd silverblue-akmods-keys
+```
+
+Build and install `akmods-keys` package:
+
+```bash
+# bash setup.sh
+# rpm-ostree install akmods-keys-0.0.2-8.fc$(rpm -E %fedora).noarch.rpm
 ```
 
 #### Optimus
@@ -149,32 +183,7 @@ If the device supports NVIDIA Optimus (e.g. hybrid graphics):
 # rpm-ostree kargs --append "nvidia.NVreg_PreserveVideoMemoryAllocations=1 nvidia.NVreg_TemporaryFilePath=/var/tmp"
 # systemctl reboot
 # systemctl enable nvidia-{suspend,resume,hibernate} --now
-```
-
-#### Secure Boot
-
-To allow the NVIDIA driver to used when using Secure Boot, see <https://github.com/CheariX/silverblue-akmods-keys> for a workaround.
-
-Install Machine Owner Key (MOK) - (the key may already exists - you don't have to overwrite):
-
-```bash
-# kmodgenca
-# mokutil --import /etc/pki/akmods/certs/public_key.der
-```
-
-Clone the silverblue-akmods-keys project, and follow the instructions:
-
-```bash
-git clone https://github.com/CheariX/silverblue-akmods-keys
-cd silverblue-akmods-keys
-```
-
-Build and install akmods-keys:
-
-```bash
-# bash setup.sh
-# rpm-ostree install akmods-keys-0.0.2-8.fc$(rpm -E %fedora).noarch.rpm
-```
+``
 
 ### TPM
 

--- a/README.md
+++ b/README.md
@@ -102,15 +102,41 @@ If you have `page flip timeouts` (freezing screen) on AMD systems:
 
 > Tip: You may want to apply the steps in Secure Boot subsection first.
 
-See the following sources for more information:
+See the following source for more information <https://negativo17.org/nvidia-driver/>.
 
-- <https://docs.fedoraproject.org/en-US/fedora-silverblue/troubleshooting/#_using_nvidia_drivers>
-- <https://rpmfusion.org/Howto/NVIDIA?highlight=%28%5CbCategoryHowto%5Cb%29#OSTree_.28Silverblue.2FKinoite.2Fetc.29>
-- <https://rpmfusion.org/Howto/NVIDIA?highlight=%28%5CbCategoryHowto%5Cb%29#Kernel_Open>
+Disable the current RPMFusion repo first:
 
 ```bash
-# rpm-ostree install akmod-nvidia xorg-x11-drv-nvidia
+# sed -ie 's/enabled=1/enabled=0/g' rpmfusion-nonfree-nvidia-driver.repo
 # rpm-ostree kargs --append "rd.driver.blacklist=nouveau,nova_core modprobe.blacklist=nouveau"
+```
+
+Add the GPG-key:
+
+```bash
+# cd /etc/pki/rpm-gpg
+# wget https://negativo17.org/repos/RPM-GPG-KEY-slaanesh
+```
+
+Add the repo:
+
+```bash
+# cd /etc/yum.repos.d
+# wget https://negativo17.org/repos/fedora-nvidia.repo
+```
+
+Change `gpgkey=` of `/etc/yum.repos.d/fedora-nvidia.repo`, to lookup the GPG locally instead:
+
+```diff
+-gpgkey=https://negativo17.org/repos/RPM-GPG-KEY-slaanesh
++gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-slaanesh
+```
+
+Install the nvidia driver:
+
+```bash
+rpm-ostree refresh-md
+rpm-ostree install nvidia-driver nvidia-settings
 ```
 
 #### Optimus
@@ -328,7 +354,7 @@ To open services and ports:
 # firewall-cmd --permanent --zone=FedoraServer --add-port=9090/tcp
 # firewall-cmd --zone=FedoraServer --remove-service=http
 # firewall-cmd --zone=FedoraServer --remove-port=9090/tcp
-# firewall-cmd --runtime-to-permanent 
+# firewall-cmd --runtime-to-permanent
 # firewall-cmd --reload
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotfiles
 
-This is a selection of settings, notes and preferences for my [Fedora Kinoite](https://fedoraproject.org/atomic-desktops/kinoite/), [Fedora Silverblue](https://fedoraproject.org/atomic-desktops/silverblue/) and [Fedora IoT](https://fedoraproject.org/iot/) Atomic installations.
+This is a selection of settings, notes and preferences for my [Fedora Kinoite](https://fedoraproject.org/atomic-desktops/kinoite/), [Fedora Silverblue](https://fedoraproject.org/atomic-desktops/silverblue/) and [Fedora IoT](https://fedoraproject.org/iot/) Atomic installations (all are running Fedora 43).
 
 > Note: Commands prepend with `# <command>` should be executed as `root` (`sudo`).
 
@@ -64,59 +64,63 @@ $ flatpak repair --user -vvv
 # flatpak repair --system -vvv
 ```
 
-### Modules
+### Kernel Modules
 
-Setting `/etc/modprobe/module.conf`  doesn't work on Atomic-releases, instead append them using `rpm-ostree kargs --append "module.parameter=foo"`. To list current kernel parameters, use `rpm-ostree kargs` and `rpm-ostree kargs --editor`  to open an editor.
+Setting `/etc/modprobe/module.conf` does not work on Atomic-releases, instead append as kernel entries, using `rpm-ostree kargs --append "module.parameter=foo"`.
 
-To disable Realtek RTW98 WiFi parameters (preventing wireless issues):
+To list current kernel parameters, use `rpm-ostree kargs` or `rpm-ostree kargs --editor` to open an editor.
+
+#### Realtek RTW89
+
+The Realtek RTW89 has many issues related to power management on Linux. Power management can be disabled by appending:
 
 ```bash
 rpm-ostree kargs --append "rtw89_core.disable_ps_mode=Y rtw89_pci.disable_aspm_l1=Y rtw89_pci.disable_aspm_l1ss=Y rtw89_pci.disable_clkreq=Y"
-````
+```
 
-### AMD
+#### AMD
 
-> Note: This will only be needed for Fedora IoT and CoreOS.
+This section is only relevant for Fedora IoT and CoreOS.
 
-For AMD/Intel, you may want to install firmware packages:
+For latest AMD/Intel hardware support, you may want to install firmware packages:
 
 ```bash
 # rpm-ostree install amd-gpu-firmware amd-ucode-firmware
 ```
 
-If you need `dri` (video-accel) support:
+If you need Hardware Video Acceleration support, such as when running Jellyfin:
 
 ```bash
 # rpm-ostree install mesa-dri-drivers
 ```
 
-#### Troubleshooting
+##### Bug: Page flip timeout
 
-If you have `page flip timeouts` (freezing screen) on AMD systems:
+If you have `page flip timeouts` (freezing screen) on AMD systems, you may want to disable panel refreshing:
 
 ```bash
 # rpm-ostree kargs --apend "amdgpu.dcdebugmask=0x10"
 ```
 
-### NVIDIA
+#### NVIDIA
 
 See the following source for more information <https://negativo17.org/nvidia-driver/>.
 
-Disable the current RPMFusion repo first:
+Make sure RPMFusion's nvidia repo is disabled first:
 
 ```bash
 # sed -ie 's/enabled=1/enabled=0/g' rpmfusion-nonfree-nvidia-driver.repo
 # rpm-ostree kargs --append "rd.driver.blacklist=nouveau,nova_core modprobe.blacklist=nouveau"
 ```
 
-Add the GPG-key:
+Add the negativo17 GPG-key:
 
 ```bash
 # cd /etc/pki/rpm-gpg
 # wget https://negativo17.org/repos/RPM-GPG-KEY-slaanesh
 ```
 
-Add the repo:
+Add the negativo17 nvidia repo:
 
 ```bash
 # cd /etc/yum.repos.d
@@ -139,18 +143,18 @@ Remove any cached GPG keys:
 Install the nvidia driver:
 
 ```bash
-rpm-ostree refresh-md
-rpm-ostree install nvidia-driver nvidia-settings
+# rpm-ostree refresh-md
+# rpm-ostree install nvidia-driver nvidia-settings
 systemctl reboot
 ```
 
-#### Secure Boot
+##### Secure Boot
 
 After reboot, the `nvidia` model may reject loading when Secure Boot is enabled.
 
-As a workaround, see <https://github.com/CheariX/silverblue-akmods-keys> for details.
+As a workaround, use <https://github.com/CheariX/silverblue-akmods-keys>.
 
-> Tip: This package may also be used for other applications that require a signed module, such as VirtualBox.
+> Tip: This package may also be used for other modules that need signing, such as for VirtualBox.
 
 Make sure the Machine Owner Key (MOK) is enrolled (the key may already exists and enrolled, do not force):
 
@@ -173,9 +177,7 @@ Build and install `akmods-keys` package:
 # rpm-ostree install akmods-keys-0.0.2-8.fc$(rpm -E %fedora).noarch.rpm
 ```
 
-#### Optimus
-
-> Note: Also install the `80-nvidia-pm.rules` udev rule, allowing the NVIDIA driver to control it's state.
+##### Optimus
 
 If the device supports NVIDIA Optimus (e.g. hybrid graphics):
 
@@ -183,7 +185,23 @@ If the device supports NVIDIA Optimus (e.g. hybrid graphics):
 # rpm-ostree kargs --append "nvidia.NVreg_PreserveVideoMemoryAllocations=1 nvidia.NVreg_TemporaryFilePath=/var/tmp"
 # systemctl reboot
 # systemctl enable nvidia-{suspend,resume,hibernate} --now
-``
+```
+
+Create `/etc/udev/rules.d/80-nvidia-pm.rules`, allowing the NVIDIA driver to control the power state:
+
+```udev
+# Enable runtime PM for NVIDIA VGA/3D controller devices on driver bind
+ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030000", TEST=="power/control", ATTR{power/control}="auto"
+ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030200", TEST=="power/control", ATTR{power/control}="auto"
+
+# Disable runtime PM for NVIDIA VGA/3D controller devices on driver unbind
+ACTION=="unbind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030000", TEST=="power/control", ATTR{power/control}="on"
+ACTION=="unbind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030200", TEST=="power/control", ATTR{power/control}="on"
+
+# Enable runtime PM for NVIDIA VGA/3D controller devices on adding device
+ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030000", TEST=="power/control", ATTR{power/control}="auto"
+ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030200", TEST=="power/control", ATTR{power/control}="auto
+```
 
 ### TPM
 
@@ -201,8 +219,8 @@ To set up TPM2 unlocking, first, find the LUKS device you want to enroll. This i
 Next, enable the required initramfs and kernel features. Note that the initramfs command below will overwrite any other initramfs changes you have made:
 
 ```bash
-# rpm-ostree kargs --append=rd.luks.options=tpm2-device=auto
 # rpm-ostree initramfs --enable --arg=-a --arg=systemd-pcrphase
+# rpm-ostree kargs --append=rd.luks.options=tpm2-device=auto
 ```
 
 Identified the disk using `cryptsetup status`, and enroll the key:
@@ -213,7 +231,15 @@ Identified the disk using `cryptsetup status`, and enroll the key:
 
 Reboot; you should not be prompted to enter your LUKS passphrase on boot.
 
-> Tip: You may want to run `systemd-cryptenroll /dev/nvme0n1p3 --wipe-slot=tpm2` when you need to re-enroll on firmware upgrades.
+#### Firmware upgrades
+
+To re-enroll (which may be needed on firmware upgrades) or wipe the current TPM2 slot:
+
+```bash
+systemd-cryptenroll /dev/nvme0n1p3 --wipe-slot=tpm2
+```
+
+Afterwards, follow the instructions to enroll the key.
 
 ### tuned
 
@@ -283,7 +309,7 @@ To use [bees](https://github.com/Zygo/bees) (dedupe agent):
 
 ### Toolbox
 
-It is discourage to install (large) software on the ostree. Try to use Flatpaks and toolboxes (`toolbox create` and `toolbox enter`) as much as possible.
+It is discourage to install (large) software on the ostree. Try to use Flatpaks and toolboxes (`toolbox create` and `toolbox enter`), and/or [BoxBuddyRS](https://github.com/Dvlv/BoxBuddyRS) as much as possible.
 
 You can pull the latest toolbox, using:
 
@@ -356,14 +382,13 @@ To open services and ports:
 # firewall-cmd --list-all-zones
 # firewall-cmd --list-all
 # firewall-cmd --permanent --zone=FedoraServer --add-service=http
-# firewall-cmd --permanent --zone=FedoraServer--add-service=https
-# firewall-cmd --permanent --zone=FedoraServer--add-service=http3
+# firewall-cmd --permanent --zone=FedoraServer --add-service=https
+# firewall-cmd --permanent --zone=FedoraServer --add-service=http3
 # firewall-cmd --permanent --zone=FedoraServer --add-service=samba
 # firewall-cmd --permanent --zone=FedoraServer --add-port=9090/udp
 # firewall-cmd --permanent --zone=FedoraServer --add-port=9090/tcp
 # firewall-cmd --zone=FedoraServer --remove-service=http
 # firewall-cmd --zone=FedoraServer --remove-port=9090/tcp
-# firewall-cmd --runtime-to-permanent
 # firewall-cmd --reload
 ```
 
@@ -378,7 +403,7 @@ See the following guides:
 Install the VSCode Podman SDK extension:
 
 ```bash
-flatpak install com.visualstudio.code.tool.podman//24.08
+flatpak install com.visualstudio.code.tool.podman//25.08
 ```
 
 Use Flatpak Permissions in Settings or [Flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal), and set the following overwrites:

--- a/etc/yum.repos.d/fedora-nvidia.repo
+++ b/etc/yum.repos.d/fedora-nvidia.repo
@@ -1,0 +1,35 @@
+[fedora-nvidia]
+name=negativo17 - Nvidia
+baseurl=https://negativo17.org/repos/nvidia/fedora-43/$basearch/
+enabled=1
+skip_if_unavailable=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-slaanesh
+enabled_metadata=1
+metadata_expire=6h
+type=rpm-md
+repo_gpgcheck=0
+
+[fedora-nvidia-source]
+name=negativo17 - Nvidia - Source
+baseurl=https://negativo17.org/repos/nvidia/fedora-$releasever/SRPMS
+enabled=0
+skip_if_unavailable=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-slaanesh
+enabled_metadata=1
+metadata_expire=6h
+type=rpm-md
+repo_gpgcheck=0
+
+[fedora-nvidia-debug]
+name=negativo17 - Nvidia - Debug
+baseurl=https://negativo17.org/repos/nvidia/fedora-$releasever/$basearch.debug/
+enabled=0
+skip_if_unavailable=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-slaanesh
+enabled_metadata=1
+metadata_expire=6h
+type=rpm-md
+repo_gpgcheck=0


### PR DESCRIPTION
This pull request updates and expands the documentation for Fedora Atomic installations, focusing on improved instructions for kernel modules, NVIDIA driver installation, TPM2 unlocking, and general system setup. It also adds the `fedora-nvidia.repo` file for the negativo17 NVIDIA driver repository. The changes clarify hardware support procedures, streamline troubleshooting, and update various commands and recommendations.

**Hardware and driver setup improvements:**

* Expanded and reorganized the kernel modules section in `README.md`, providing clearer instructions for Realtek RTW89, AMD, and NVIDIA hardware, including detailed steps for disabling problematic features, installing firmware, and troubleshooting.
* Added comprehensive instructions for installing NVIDIA drivers using the negativo17 repository, including secure boot considerations, repo setup, and power management for Optimus devices.
* Added the `fedora-nvidia.repo` file to the repository for easier negativo17 NVIDIA driver installation.

**TPM2 and disk encryption guidance:**

* Improved TPM2 unlocking documentation: clarified the order of enabling kernel arguments, added a section on handling firmware upgrades, and provided explicit re-enrollment instructions.